### PR TITLE
Add offset of episode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $ yarn start
 - `Pattern`: 标题模板，只有匹配至少一条的项目会被返回，模板本身为 [正则表达式](https://en.wikipedia.org/wiki/Regular_expression) ，表达式中需要包含 [命名捕获组](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges) （即 `(?<episode>\d+)` )，用于提供剧集信息。
 - `Series`: 系列名称，网页端会从 Sonarr 获取所有系列名称，如果没有找到需要的系列，可能需要首先在 Sonarr 中添加系列。
 - `Season`: 季度代码，一般为两位数字，如 `01`。
+- `Offset`: 剧集号偏移量，用于修复从第一季开始的序号和从本季开始的序号。如`-26`。
 - `Language`: 语言，为剧集对应语言的英文名，如 `Chinese`，需要符合系列所需的语言设定，否则无法被 Sonarr 抓取。
 - `Quality`: 质量，可用的值可以参考 [Sonarr 源码](https://github.com/Sonarr/Sonarr/blob/develop/src/NzbDrone.Core/Parser/QualityParser.cs) ，Sonarr 似乎不支持对 RSS 推送的项目自动检测质量，网页端默认填写的值为 `WEBDL 1080p`。
 

--- a/server/index.js
+++ b/server/index.js
@@ -40,11 +40,12 @@ const route = async (req, res) => {
         link,
         torrent: [{ pubDate }],
       } = item;
-      for (const { pattern, series, season, language, quality } of rules) {
+      for (const { pattern, series, season, language, quality, offset } of rules) {
         const match = pattern.exec(title);
         if (!match) continue;
         const { episode } = match.groups;
-        const normalized = `${series} - S${season}E${episode} - ${language} - ${quality}`;
+        const episodeWithOffset = Number.parseInt(episode) + (Number.parseInt(offset) || 0);
+        const normalized = `${series} - S${season}E${episodeWithOffset} - ${language} - ${quality}`;
         items.push({
           title: [normalized],
           pubDate,

--- a/src/Edit.jsx
+++ b/src/Edit.jsx
@@ -75,6 +75,7 @@ const PatternEdit = (props) => {
         />
         <AutocompleteInput fullWidth source="series" choices={choices} />
         <TextInput source="season" />
+        <TextInput source="offset" />
         <TextInput source="language" />
         <TextInput source="quality" />
       </SimpleForm>
@@ -107,6 +108,7 @@ const PatternCreate = (props) => {
         />
         <AutocompleteInput fullWidth source="series" choices={choices} />
         <TextInput source="season" />
+        <TextInput source="offset" />
         <TextInput source="language" />
         <TextInput source="quality" />
       </SimpleForm>


### PR DESCRIPTION
有些字幕组的剧集是从第一季开始持续编号的，对于这种情况虽然Sonarr能够正确识别文件，但是似乎不会通过RSS触发下载。

增加了一个offset字段，用于手动设置偏移量，从而使每季都从1开始编号。