### PR TITLE
Allow disabling jwt auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ ADMIN_PASSWORD=your_admin_password
 
 `ADMIN_USERNAME` 和 `ADMIN_PASSWORD` 用于登陆系统，未登陆无法访问。
 
+如果你已通过反向代理添加了认证能力，可以通过增加环境变量 `DISABLE_AUTH=true` 来禁用内置的基于 JWT 的用户认证。
+
 然后运行（需要 Node.js 环境）：
 
 ```bash

--- a/server/jwt.js
+++ b/server/jwt.js
@@ -1,3 +1,8 @@
+if (process.env.DISABLE_AUTH === 'true') {
+  module.exports = [];
+  return;
+}
+
 const server = require('./server');
 
 const fs = require('fs');

--- a/src/auth.js
+++ b/src/auth.js
@@ -5,22 +5,25 @@ const authProvider = {
     const { data } = await axios.post('/auth/login', {
       username, password
     });
+    localStorage.removeItem('need_login');
     localStorage.setItem('token', data.token);
   },
   checkError: (error) => {
     const status = error.status;
     if (status === 401 || status === 403) {
       localStorage.removeItem('token');
+      localStorage.setItem('need_login', true);
       return Promise.reject();
     }
     // other error code (404, 500, etc): no need to log out
     return Promise.resolve();
   },
-  checkAuth: () => localStorage.getItem('token')
-    ? Promise.resolve()
-    : Promise.reject(),
+  checkAuth: () => localStorage.getItem('need_login')
+    ? Promise.reject()
+    : Promise.resolve(),
   logout: () => {
     localStorage.removeItem('token');
+    localStorage.setItem('need_login', true);
     return Promise.resolve();
   },
   getPermissions: async () => 'admin',

--- a/src/data.js
+++ b/src/data.js
@@ -5,7 +5,9 @@ const httpClient = (url, options = {}) => {
     if (!options.headers) {
         options.headers = new Headers();
     }
-    options.headers.set('Authorization', `Bearer ${localStorage.getItem('token')}`);
+    if (localStorage.getItem('token')) {
+        options.headers.set('Authorization', `Bearer ${localStorage.getItem('token')}`);
+    }
     return fetchUtils.fetchJson(url, options);
 };
 

--- a/src/patterns/Edit.jsx
+++ b/src/patterns/Edit.jsx
@@ -33,11 +33,12 @@ const EscapeButton = () => {
 };
 
 const choicesFetcher = async (api) => {
-  const { data } = await axios(`/sonarr${api}`, {
+  const opt = localStorage.getItem("token") ? {
     headers: {
       Authorization: `Bearer ${localStorage.getItem("token")}`,
-    },
-  });
+    }
+  } : {};
+  const { data } = await axios(`/sonarr${api}`, opt);
   return data;
 };
 


### PR DESCRIPTION
有些用户可能已经通过前置的反向代理提供认证了。本 PR 允许用户禁用内置的认证来避免需要进行双重认证。