### PR TITLE
Fix offset and improve edit form

### DIFF
--- a/server/rss.js
+++ b/server/rss.js
@@ -31,7 +31,7 @@ const route = async (req, res) => {
         link,
         torrent: [{ pubDate }],
       } = item;
-      for (const { pattern, series, season, language, quality } of rules) {
+      for (const { pattern, series, season, language, quality, offset } of rules) {
         const match = title.match(pattern);
         if (!match?.groups?.episode) continue;
         const { episode } = match.groups;

--- a/src/patterns/Edit.jsx
+++ b/src/patterns/Edit.jsx
@@ -250,6 +250,7 @@ const PatternEdit = (props) => {
           <PatternInput />
           <AutocompleteInput fullWidth source="series" choices={choices} />
           <SeasonsInput series={series} />
+          <TextInput source="offset" />
           <TextInput source="language" />
           <TextInput source="quality" />
         </SimpleForm>
@@ -282,7 +283,7 @@ const PatternCreate = (props) => {
           <RemoteInput />
           <PatternInput />
           <AutocompleteInput fullWidth source="series" choices={choices} />
-          <TextInput source="season" />
+          <SeasonsInput series={series} />
           <TextInput source="offset" />
           <TextInput source="language" />
           <TextInput source="quality" />


### PR DESCRIPTION
1. 在 `Create` 中，使用 `SeasonsInput` 而非 `TextInput`
2. 在 `Edit` 中，添加了缺失的 `offset` 输入框，修复了`rss.js`中缺少offset的bug

fixes #14 