### PR TITLE
使用Dockerfile多阶段构建及pkg打包减小镜像体积

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /build/
 .env
 docker-compose.yml
+/index*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,20 @@
-FROM node:14
-WORKDIR /usr/src/app
+FROM node:16 AS builder
+WORKDIR /
 
 COPY package.json ./
 COPY yarn.lock ./
-RUN yarn install --production=true
-COPY build ./build
+COPY public ./public
 COPY server ./server
+COPY src ./src
+RUN yarn install
+RUN yarn build
+RUN chmod 755 ./index-*
+
+FROM alpine:latest 
+RUN apk --no-cache add ca-certificates
+WORKDIR /
+COPY --from=builder /build ./build
+COPY --from=builder /index-alpine ./mikanarr
 EXPOSE 12306
-VOLUME /usr/src/app/data
-CMD ["yarn", "start"]
+VOLUME /data
+CMD ["./mikanarr"]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev:server": "dotenv -- nodemon --signal SIGINT --watch server server/index.js",
     "dev:web": "dotenv -- react-scripts start",
     "build": "npm-run-all build:*",
-    "build:web": "react-scripts build"
+    "build:web": "react-scripts build",
+    "build:server": "pkg -t linux,alpine server/index.js"
   },
   "keywords": [],
   "author": "",
@@ -45,7 +46,8 @@
   "devDependencies": {
     "nodemon": "^2.0.7",
     "npm-run-all": "^4.1.5",
-    "react-scripts": "^4.0.3"
+    "react-scripts": "^5.0.0",
+    "pkg": "^5.5.1"
   },
   "resolutions": {
     "react-admin/@material-ui/core": "4.11.4"

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,4 @@
+require('dotenv').config({ path: './data/.env' })
 const server = require('./server');
 const express = require('express');
 server.use(express.json());


### PR DESCRIPTION
使用多阶段构建以减少发布时引入过多构建的中间文件。
使用pkg打包成单一的可执行文件方便分发（我个人有时会在非Docker环境下运行，喜欢go那种一个可执行文件就能搞定的方式，所以就打包了一下）。